### PR TITLE
fhost: allow configuration at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 __pycache__/
-.py[cod]
+/fhost.cfg

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,13 @@ For all other servers, set ``FHOST_USE_X_ACCEL_REDIRECT`` to ``False`` and
 Otherwise, Flask will serve the file with chunked encoding, which sucks and
 should be avoided at all costs.
 
+You can configure these parameters by creating a file called ``fhost.cfg``
+and placing normal python assignment statements in it. For example::
+
+    FHOST_USE_ACCEL_REDIRECT = False
+    FHOST_USE_X_SENDFILE = True
+    MAX_URL_LENGTH = 4096
+
 To make files expire, simply create a cronjob that runs ``cleanup.py`` every
 now and then.
 

--- a/fhost.py
+++ b/fhost.py
@@ -68,6 +68,8 @@ app.config["FHOST_UPLOAD_BLACKLIST"] = "tornodes.txt"
 app.config["NSFW_DETECT"] = False
 app.config["NSFW_THRESHOLD"] = 0.608
 
+app.config.from_pyfile("fhost.cfg", silent=True)
+
 if app.config["NSFW_DETECT"]:
     from nsfw_detect import NSFWDetector
     nsfw = NSFWDetector()


### PR DESCRIPTION
This reads configuration from a file called `fhost.cfg` if it exists,
allowing users to configure the server without having to maintain a fork.

I also used this opportunity to remove the gitignore entry for `.py[cod]`. It's only needed for python2, as python3 always places bytecode files inside `__pycache__`, which was already ignored.