### PR TITLE
remove short_url and add in-tree URLencoder

### DIFF
--- a/fhost.py
+++ b/fhost.py
@@ -29,7 +29,6 @@ from magic import Magic
 from mimetypes import guess_extension
 import sys
 import requests
-from short_url import UrlEncoder
 from validators import url as url_valid
 from pathlib import Path
 
@@ -90,8 +89,6 @@ Please install python-magic.""")
 
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
-
-su = UrlEncoder(alphabet=app.config["URL_ALPHABET"], block_size=16)
 
 class URL(db.Model):
     id = db.Column(db.Integer, primary_key = True)
@@ -206,6 +203,30 @@ class File(db.Model):
         db.session.add(f)
         db.session.commit()
         return f
+
+
+
+class UrlEncoder(object):
+    def __init__(self,alphabet):
+        self.alphabet = alphabet
+
+    def enbase(self, x, min_length):
+        n = len(self.alphabet)
+        str = ""
+        while x > 0:
+            str = (self.alphabet[int(x % n)]) + str
+            x = int(x // n)
+        padding = self.alphabet[0] * (min_length - len(str))
+        return '%s%s' % (padding, str)
+
+    def debase(self, x):
+        n = len(self.alphabet)
+        result = 0
+        for i, c in enumerate(reversed(x)):
+            result += self.alphabet.index(c) * (n ** i)
+        return result
+
+su = UrlEncoder(alphabet=app.config["URL_ALPHABET"])
 
 def fhost_url(scheme=None):
     if not scheme:

--- a/fhost.py
+++ b/fhost.py
@@ -98,7 +98,7 @@ class URL(db.Model):
         self.url = url
 
     def getname(self):
-        return su.enbase(self.id, 1)
+        return su.enbase(self.id)
 
     def geturl(self):
         return url_for("get", path=self.getname(), _external=True) + "\n"
@@ -129,7 +129,7 @@ class File(db.Model):
         self.addr = addr
 
     def getname(self):
-        return u"{0}{1}".format(su.enbase(self.id, 1), self.ext)
+        return u"{0}{1}".format(su.enbase(self.id), self.ext)
 
     def geturl(self):
         n = self.getname()
@@ -207,16 +207,17 @@ class File(db.Model):
 
 
 class UrlEncoder(object):
-    def __init__(self,alphabet):
+    def __init__(self,alphabet, min_length):
         self.alphabet = alphabet
+        self.min_length = min_length
 
-    def enbase(self, x, min_length):
+    def enbase(self, x):
         n = len(self.alphabet)
         str = ""
         while x > 0:
             str = (self.alphabet[int(x % n)]) + str
             x = int(x // n)
-        padding = self.alphabet[0] * (min_length - len(str))
+        padding = self.alphabet[0] * (self.min_length - len(str))
         return '%s%s' % (padding, str)
 
     def debase(self, x):
@@ -226,7 +227,7 @@ class UrlEncoder(object):
             result += self.alphabet.index(c) * (n ** i)
         return result
 
-su = UrlEncoder(alphabet=app.config["URL_ALPHABET"])
+su = UrlEncoder(alphabet=app.config["URL_ALPHABET"], min_length=1)
 
 def fhost_url(scheme=None):
     if not scheme:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ Flask_SQLAlchemy
 validators
 flask_migrate
 python_magic
-short_url


### PR DESCRIPTION
This PR removes the short_url dependency  as per issue #41.
This implementation is pretty much the same as in short_url except I've rewritten the enbase() function to be iterative instead of recursive. 
The only functions of the class are enbase() and debase() since those were the only functions being used by fhost. 
My python is very rusty so if anything could be better I'll gladly modify this PR :) 
