### PR TITLE
Add leniency in trailing slash to better accommodate instances mounted in subdirectories

### DIFF
--- a/fhost.py
+++ b/fhost.py
@@ -484,7 +484,7 @@ def get(path, secret=None):
 
     abort(404)
 
-@app.route("/", methods=["GET", "POST"])
+@app.route("/", methods=["GET", "POST"], strict_slashes=False)
 def fhost():
     if request.method == "POST":
         sf = None


### PR DESCRIPTION
If 0x0 is mounted in a subdirectory of a domain, e.g. `https://example.com/0x0`, e.g. via:
```
$ uwsgi --socket 0.0.0.0:80 --protocol=http --manage-script-name --mount /0x0=fhost:app
```

the welcome message gives non-working commands:
```
THE NULL POINTER
================

HTTP POST files here:
    curl -F'file=@yourfile.png' http://example.com/0x0
<...>
```
```
$ curl -F'file=@image.png' http://example.com/0x0
<!doctype html>
<html lang=en>
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to the target URL: <a href="http://example.com/0x0/">http://example.com/0x0/</a>. If not, click the link.
```

The issue is that flask is expecting to see a trailing slash in such URLs, but it is explicitly removed inside `index.html`. We can confirm that adding a trailing slash solves the issue:
```
$ curl -F'file=@image.png' http://example.com/0x0/
http://example.com/0x0/E.png
```
There are two solutions: either add the trailing slash for all urls in `index.html`, or allow leniency in the presence of a trailing slash by adding `strict_slashes=False`:
```python
@app.route("/", methods=["GET", "POST"], strict_slashes=False)
```